### PR TITLE
Fix to auth errors using fopenRequest

### DIFF
--- a/gapi.class.php
+++ b/gapi.class.php
@@ -795,7 +795,10 @@ class gapiRequest {
     $http_options = array('method'=>'GET', 'timeout'=>3);
 
     if (is_array($headers)) {
-      $headers = implode("\r\n", $headers) . "\r\n";
+      foreach ($headers as $key => $value) {
+        $string_headers[] = "$key: $value";
+      }
+      $headers = implode("\r\n", $string_headers) . "\r\n";
     }
     else {
       $headers = '';


### PR DESCRIPTION
Headers were not being serialized correctly, so authorization would fail. It looks like curl was doing it the correct way,