### PR TITLE
Escape reserved characters without escaping logic operators

### DIFF
--- a/gapi.class.php
+++ b/gapi.class.php
@@ -237,8 +237,8 @@ class gapi {
     $valid_operators = '(!~|=~|==|!=|>|<|>=|<=|=@|!@)';
 
     $filter = preg_replace('/\s\s+/', ' ', trim($filter)); //Clean duplicate whitespace
-    $filter = str_replace(array(',', ';'), array('\,', '\;'), $filter); //Escape Google Analytics reserved characters
     $filter = preg_replace('/(&&\s*|\|\|\s*|^)([a-z0-9]+)(\s*' . $valid_operators . ')/i','$1ga:$2$3',$filter); //Prefix ga: to metrics and dimensions
+    $filter = preg_replace('/([,;]){1}(?!ga\:)/', '\\\\$1', $filter); //Escape Google Analytics reserved characters
     $filter = preg_replace('/[\'\"]/i', '', $filter); //Clear invalid quote characters
     $filter = preg_replace(array('/\s*&&\s*/','/\s*\|\|\s*/','/\s*' . $valid_operators . '\s*/'), array(';', ',', '$1'), $filter); //Clean up operators
 


### PR DESCRIPTION
When using multiple filters, they are separated by logical operators AND, OR (; and , respectively in GA query syntax). To avoid screening them with str_replace we can first check valid operators and add 'ga:' prefix where missing and then screen only those reserved characters which are not followed by 'ga:' prefix.
See: https://developers.google.com/analytics/devguides/reporting/core/v3/reference#combiningFilters